### PR TITLE
Add test to ensure that refresh_from_db clears changed fields

### DIFF
--- a/tests/test_tracking_model.py
+++ b/tests/test_tracking_model.py
@@ -96,6 +96,12 @@ class AllFieldsTrackedModelTests(TestCase):
         self.a.text_field = "init_value"
         self.assertDictEqual(self.a.tracker.changed, {})
 
+    def test_refresh_from_db_clears_changes(self):
+        self.a.text_field = "next_value"
+        self.assertDictEqual(self.a.tracker.changed, {"text_field": "init_value"})
+        self.a.refresh_from_db()
+        self.assertDictEqual(self.a.tracker.changed, {})
+
 
 class DeferredFieldsTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
I wanted to upstream an old fix that we've had in our codebase that was making sure that refresh_from_db cleared the tracker but after writing a test for it, realised that it's already working, which means that we can remove our fix. 

I think it would be nice to have a test in this library to ensure the behaviour works, so here it is.