### PR TITLE
Allow Users to override tracker class

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Out[1]: ["I", "am", "your", "father"]
 ```
 DTM handles deferred fields well.
 ```python
+# from django.db.models.query_utils import DeferredAttribute
 In [1]: e = Example.objects.only("array").first()
 In [2]: e.text = "I am not your father" 
 In [3]: e.tracker.changed
@@ -83,6 +84,17 @@ class Example(models.Model):
     TRACKED_FIELDS = ["first"]
     first = models.TextField()
     second = models.TextField()
+```
+You can also implement your own Tracker class:
+```python
+from tracking_model import Tracker
+
+class SuperTracker(Tracker):
+    def has_changed(self, field):
+      return field in self.changed
+
+class Example(models.Model):
+    TRACKER_CLASS = SuperTracker
 ```
 
 ## Requirements

--- a/tests/models.py
+++ b/tests/models.py
@@ -39,9 +39,6 @@ class NarrowTrackedModel(TrackingModelMixin, models.Model):
 
 
 class CustomTracker(Tracker):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def has_changed(self, field):
         if field not in self.tracked_fields:
             raise ValueError("%s is not tracked" % field)
@@ -49,7 +46,7 @@ class CustomTracker(Tracker):
 
 
 class WithCustomTrackerModel(TrackingModelMixin, models.Model):
-    tracker_class = CustomTracker
+    TRACKER_CLASS = CustomTracker
     TRACKED_FIELDS = ["first"]
     first = models.TextField(null=True)
     second = models.TextField(null=True)
@@ -60,7 +57,7 @@ class InvalidTracker:
 
 
 class WithInvalidTrackerModel(TrackingModelMixin, models.Model):
-    tracker_class = InvalidTracker
+    TRACKER_CLASS = InvalidTracker
     TRACKED_FIELDS = ["first"]
     first = models.TextField(null=True)
     second = models.TextField(null=True)

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-from tracking_model import TrackingModelMixin
+from tracking_model import TrackingModelMixin, Tracker
 
 
 class ModelB(TrackingModelMixin, models.Model):
@@ -33,6 +33,34 @@ class MutableModel(TrackingModelMixin, models.Model):
 
 
 class NarrowTrackedModel(TrackingModelMixin, models.Model):
+    TRACKED_FIELDS = ["first"]
+    first = models.TextField(null=True)
+    second = models.TextField(null=True)
+
+
+class CustomTracker(Tracker):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def has_changed(self, field):
+        if field not in self.tracked_fields:
+            raise ValueError("%s is not tracked" % field)
+        return field in self.changed
+
+
+class WithCustomTrackerModel(TrackingModelMixin, models.Model):
+    tracker_class = CustomTracker
+    TRACKED_FIELDS = ["first"]
+    first = models.TextField(null=True)
+    second = models.TextField(null=True)
+
+
+class InvalidTracker:
+    pass
+
+
+class WithInvalidTrackerModel(TrackingModelMixin, models.Model):
+    tracker_class = InvalidTracker
     TRACKED_FIELDS = ["first"]
     first = models.TextField(null=True)
     second = models.TextField(null=True)

--- a/tests/test_tracking_model.py
+++ b/tests/test_tracking_model.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from django.db.models.query_utils import DeferredAttribute
 from django.test import TestCase
 
-from .models import ModelA, ModelB, SignalModel, MutableModel, NarrowTrackedModel
+from .models import ModelA, ModelB, SignalModel, MutableModel, NarrowTrackedModel, WithCustomTrackerModel, \
+    WithInvalidTrackerModel
 from .signals import *
 
 
@@ -211,3 +212,28 @@ class TrackedFieldsOnlyTests(TestCase):
         self.obj.first = "Ciao ciao"
         self.obj.second = "Italiano"
         self.assertDictEqual(self.obj.tracker.changed, {"first": "Ciao"})
+
+
+class OverrideTrackerTests(TestCase):
+
+    def test_tracking_mixin_raises_error_if_tracker_class_is_invalid(self):
+        with self.assertRaises(TypeError) as e:
+            WithInvalidTrackerModel(first="Joh", second="Doe")
+
+        self.assertEqual(
+            str(e.exception),
+            "tracker_class must be subclass of Tracker.",
+        )
+
+    def test_instance_can_use_new_methods_of_tracker_class(self):
+        instance = WithCustomTrackerModel(first="John", second="Doe")
+        instance.first = "Mary"
+        instance.second = "Jane"
+        self.assertEqual(instance.tracker.has_changed("first"), True)
+
+        with self.assertRaises(ValueError) as e:
+            instance.tracker.has_changed("second")
+        self.assertEqual(
+            str(e.exception),
+            "second is not tracked",
+        )

--- a/tests/test_tracking_model.py
+++ b/tests/test_tracking_model.py
@@ -224,11 +224,11 @@ class TrackedFieldsOnlyTests(TestCase):
 class OverrideTrackerTests(TestCase):
     def test_tracking_mixin_raises_error_if_tracker_class_is_invalid(self):
         with self.assertRaises(TypeError) as e:
-            WithInvalidTrackerModel(first="Joh", second="Doe")
+            WithInvalidTrackerModel(first="Joh", second="Doe").tracker
 
         self.assertEqual(
             str(e.exception),
-            "tracker_class must be subclass of Tracker.",
+            "TRACKER_CLASS must be a subclass of Tracker.",
         )
 
     def test_instance_can_use_new_methods_of_tracker_class(self):

--- a/tests/test_tracking_model.py
+++ b/tests/test_tracking_model.py
@@ -3,8 +3,15 @@ from copy import deepcopy
 from django.db.models.query_utils import DeferredAttribute
 from django.test import TestCase
 
-from .models import ModelA, ModelB, SignalModel, MutableModel, NarrowTrackedModel, WithCustomTrackerModel, \
-    WithInvalidTrackerModel
+from .models import (
+    ModelA,
+    ModelB,
+    SignalModel,
+    MutableModel,
+    NarrowTrackedModel,
+    WithCustomTrackerModel,
+    WithInvalidTrackerModel,
+)
 from .signals import *
 
 
@@ -215,7 +222,6 @@ class TrackedFieldsOnlyTests(TestCase):
 
 
 class OverrideTrackerTests(TestCase):
-
     def test_tracking_mixin_raises_error_if_tracker_class_is_invalid(self):
         with self.assertRaises(TypeError) as e:
             WithInvalidTrackerModel(first="Joh", second="Doe")

--- a/tracking_model/__init__.py
+++ b/tracking_model/__init__.py
@@ -1,1 +1,1 @@
-from .mixins import TrackingModelMixin
+from .mixins import TrackingModelMixin, Tracker

--- a/tracking_model/mixins.py
+++ b/tracking_model/mixins.py
@@ -58,17 +58,16 @@ class TrackingModelMixin(object):
                 self.tracker.changed = {}
 
     def __setattr__(self, name, value):
-        if hasattr(self, "_initialized"):
-            if name in self.tracker.tracked_fields:
-                if name not in self.tracker.changed:
-                    if name in self.__dict__:
-                        old_value = getattr(self, name)
-                        if value != old_value:
-                            self.tracker.changed[name] = old_value
-                    else:
-                        self.tracker.changed[name] = DeferredAttribute
-                else:
-                    if value == self.tracker.changed[name]:
-                        self.tracker.changed.pop(name)
+        if hasattr(self, "_initialized") and name in self.tracker.tracked_fields:
+            if name in self.tracker.changed:
+                if value == self.tracker.changed[name]:
+                    self.tracker.changed.pop(name)
+
+            elif name in self.__dict__:
+                old_value = getattr(self, name)
+                if value != old_value:
+                    self.tracker.changed[name] = old_value
+            else:
+                self.tracker.changed[name] = DeferredAttribute
 
         super(TrackingModelMixin, self).__setattr__(name, value)

--- a/tracking_model/mixins.py
+++ b/tracking_model/mixins.py
@@ -12,10 +12,23 @@ class Tracker(object):
 class TrackingModelMixin(object):
 
     TRACKED_FIELDS = None
+    tracker_class = Tracker
 
     def __init__(self, *args, **kwargs):
+        self._validate_tracker_class()
         super(TrackingModelMixin, self).__init__(*args, **kwargs)
         self._initialized = True
+
+    def _validate_tracker_class(self):
+        if not self.tracker_class:
+            raise AttributeError(
+                "Please set tracker_class attribute."
+            )
+
+        if not issubclass(self.tracker_class, Tracker):
+            raise TypeError(
+                "tracker_class must be subclass of Tracker."
+            )
 
     @property
     def tracker(self):
@@ -27,7 +40,7 @@ class TrackingModelMixin(object):
             if not self.TRACKED_FIELDS:
                 instance_class = type(self)
                 instance_class.TRACKED_FIELDS = {f.attname for f in instance_class._meta.concrete_fields}
-            tracker = self._state._tracker = Tracker(self)
+            tracker = self._state._tracker = self.tracker_class(self)
         return tracker
 
     def save(


### PR DESCRIPTION
# Motivation
Currently `Tracker` is tightly coupled with `TrackingModelMixin`, if we want to add some methods that replicate the behavior of `model_utils.FieldTracker` methods, we need to override the `TrackingModelMixin` and rewrite the `tracker` property and write a new Tracker class with the required methods.

To avoid this, I'm adding a new attribute `tracker_class` to `TrackingModelMixin` which defaults to `Tracker`.

This helps us to easily override the `Tracker` and write required methods, without duplicated lines of code.

@drozdowsky @browniebroke please let me know what you think about this approach.

Finally, thank you ❤️ for creating this library, it helped me solve some problems that were coming up because of `FieldTracker`.

